### PR TITLE
config-extra is not installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 ------------
 
 1. cd "$HOME/.drush"
-2. composer global require "drush/config-extra"
+2. composer require "drush/config-extra"
 3. drush cc drush
 
 Resources


### PR DESCRIPTION
Since Drush will not be looking in Composer's vendor directory for commands and commands are to be installed in a user's .drush directory, I believe the installation instructions should not specify 'global' in step 2.
